### PR TITLE
simplify

### DIFF
--- a/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
+++ b/sql/catalyst/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBase.g4
@@ -246,11 +246,15 @@ statement
     | SET TIME ZONE interval                                           #setTimeZone
     | SET TIME ZONE timezone=(STRING | LOCAL)                          #setTimeZone
     | SET TIME ZONE .*?                                                #setTimeZone
-    | SET key=quotedIdentifier (EQ value=.*)?                          #setQuotedConfiguration
+    | SET configKey (EQ .*?)?                                          #setQuotedConfiguration
     | SET .*?                                                          #setConfiguration
-    | RESET key=quotedIdentifier                                       #resetQuotedConfiguration
+    | RESET configKey                                                  #resetQuotedConfiguration
     | RESET .*?                                                        #resetConfiguration
     | unsupportedHiveNativeCommands .*?                                #failNativeCommand
+    ;
+
+configKey
+    : quotedIdentifier
     ;
 
 unsupportedHiveNativeCommands

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -86,8 +86,8 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
 
   override def visitSetQuotedConfiguration(ctx: SetQuotedConfigurationContext)
     : LogicalPlan = withOrigin(ctx) {
-    val keyStr = ctx.key.getText.replaceAll("`", "")
-    if (ctx.value != null) {
+    val keyStr = ctx.configKey().getText
+    if (ctx.EQ() != null) {
       SetCommand(Some(keyStr -> Option(remainder(ctx.EQ().getSymbol).trim)))
     } else {
       SetCommand(Some(keyStr -> None))
@@ -117,7 +117,7 @@ class SparkSqlAstBuilder(conf: SQLConf) extends AstBuilder(conf) {
 
   override def visitResetQuotedConfiguration(
       ctx: ResetQuotedConfigurationContext): LogicalPlan = withOrigin(ctx) {
-    ResetCommand(Some(ctx.key.getText.replaceAll("`", "")))
+    ResetCommand(Some(ctx.configKey().getText))
   }
 
   /**


### PR DESCRIPTION
I tried to address my own comments and add the `key` and `value` label, but had no luck.

This PR just does 2 simplifications:
1.  reuse the `quotedIdentifier` parser rule instead of stripping backticks by our own
2. remove the `value` label as we can't use it anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maropu/spark/4)
<!-- Reviewable:end -->
